### PR TITLE
Switch dokku branch from `master` to `legacy`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,14 +32,14 @@ RUN apt-get update -y && \
 
 RUN adduser --disabled-password --gecos "" --home /data dokku
 
-ADD https://github.com/protonet/dokku/archive/master.zip /tmp/dokku.zip
+ADD https://github.com/experimental-platform/dokku/archive/legacy.zip /tmp/dokku.zip
 RUN unzip /tmp/dokku.zip -d /tmp/ && \
     mkdir -p /var/lib/dokku/ && \
     mv /tmp/dokku-master/* /var/lib/dokku/ && \
     rm -rf /tmp/dokku-master /tmp/dokku.zip && \
     ln -s /var/lib/dokku/dokku /usr/local/bin/dokku
 
-ADD https://github.com/protonet/dokku-linkfile/archive/master.zip /tmp/dokku-linkfile.zip
+ADD https://github.com/experimental-platform/dokku-linkfile/archive/master.zip /tmp/dokku-linkfile.zip
 RUN unzip /tmp/dokku-linkfile.zip -d /tmp/ && \
     mkdir -p /var/lib/dokku/plugins/linkfile/ && \
     mv /tmp/dokku-linkfile-master/* /var/lib/dokku/plugins/linkfile/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ RUN adduser --disabled-password --gecos "" --home /data dokku
 ADD https://github.com/experimental-platform/dokku/archive/legacy.zip /tmp/dokku.zip
 RUN unzip /tmp/dokku.zip -d /tmp/ && \
     mkdir -p /var/lib/dokku/ && \
-    mv /tmp/dokku-master/* /var/lib/dokku/ && \
-    rm -rf /tmp/dokku-master /tmp/dokku.zip && \
+    mv /tmp/dokku-legacy/* /var/lib/dokku/ && \
+    rm -rf /tmp/dokku-legacy /tmp/dokku.zip && \
     ln -s /var/lib/dokku/dokku /usr/local/bin/dokku
 
 ADD https://github.com/experimental-platform/dokku-linkfile/archive/master.zip /tmp/dokku-linkfile.zip

--- a/plugins/protonet-ps/commands
+++ b/plugins/protonet-ps/commands
@@ -12,7 +12,7 @@ case "$1" in
 
     for dokku_app in $dokku_apps; do
       APP=$(basename $dokku_app)
-      DOKKU_APP_CIDS=$(get_app_container_ids $APP)
+      DOKKU_APP_CIDS=$(get_container_ids $APP)
       DOCKER_RUNNING_CONTAINERS=$(docker ps -q --no-trunc)
       if [[ -n $DOKKU_APP_CIDS ]]; then
         for DOKKU_APP_CID in $DOKKU_APP_CIDS; do


### PR DESCRIPTION
The current master branch of dokku has some small woes when used in conjunction with our modification and plugins. To mitigate we delay the upgrade a little bit.
