### PR TITLE
Fixes spurious permission errors

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,10 +2,9 @@
 set -e
 
 chown -R dokku:dokku $DOKKU_ROOT
-
 getent group docker && groupmod -g $DOCKER_GID docker || groupadd -g $DOCKER_GID docker
-
 usermod -a -G docker dokku
+chmod 666 /var/run/docker.sock
 
 sudo -nE -u dokku bash -c '/usr/local/bin/prepare_dokku'
 


### PR DESCRIPTION
Fixes spurious permission errors like this one:

```
bash[957]: Post http:///var/run/docker.sock/v1.19/[...]: dial unix /var/run/docker.sock: permission denied.
```
