### PR TITLE
Fix the messages about rsyslog not being found.

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -20,7 +20,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:rsyslog]
-command=/sbin/rsyslogd -n -c3
+command=/usr/sbin/rsyslogd -n -c3
 numprocs=1
 startsecs = 5
 stopwaitsecs = 5


### PR DESCRIPTION
Apparently it works:

```
$ docker logs dokku 2>&1 | grep rsyslog
2015-09-24 07:42:57,698 INFO spawned: 'rsyslog' with pid 420
rsyslogd: error: option -c is no longer supported - ignored
rsyslogd: imklog: cannot open kernel log (/proc/kmsg): Operation not permitted.
rsyslogd: activation of module imklog failed [try http://www.rsyslog.com/e/2145 ]
rsyslogd: Could no open output pipe '/dev/xconsole': No such file or directory [try http://www.rsyslog.com/e/2039 ]
2015-09-24 07:43:02,861 INFO success: rsyslog entered RUNNING state, process has stayed up for > than 5 seconds (startsecs)
```
